### PR TITLE
Add dynamic copyright year generation

### DIFF
--- a/hooks.py
+++ b/hooks.py
@@ -1,0 +1,13 @@
+"""MkDocs hooks for dynamic configuration."""
+
+from datetime import datetime
+
+
+def on_config(config, **kwargs):
+    """Update configuration with dynamic values before build."""
+    current_year = datetime.now().year
+    config["copyright"] = (
+        f"Copyright &copy; {current_year} OpsDuty - "
+        '<a href="#__consent">Cookie Settings</a>'
+    )
+    return config

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,9 +4,8 @@ strict: true
 site_url: https://docs.opsduty.io
 repo_name: opsduty/opsduty-docs
 
-copyright: >
-  Copyright &copy; 2026 OpsDuty -
-  <a href="#__consent">Cookie Settings</a>
+hooks:
+  - hooks.py
 
 plugins:
   - social


### PR DESCRIPTION
## Summary
Implements automatic copyright year updates at build time using MkDocs hooks, eliminating the need for manual yearly updates.

## Changes
- Created `hooks.py` with `on_config` hook to dynamically set copyright year
- Updated `mkdocs.yml` to use hooks instead of static copyright configuration
- Copyright year now automatically reflects current year during build

## Testing
- Verified MkDocs build completes successfully
- Confirmed generated site contains correct copyright year (2026)

## Resolves
Closes OPS-10

🤖 Generated with [Claude Code](https://claude.com/claude-code)