### PR TITLE
Document the mcp OAuth2 scope

### DIFF
--- a/docs/api/oauth2.md
+++ b/docs/api/oauth2.md
@@ -20,6 +20,7 @@ The following scopes are currently available:
 
 - **api** - Allow access to our GraphQL API.
 - **api:v1** - Allow access to our REST API v1.
+- **mcp** - Allow access to our MCP API.
 
 The scopes are requested when the token is generated.
 


### PR DESCRIPTION
The OAuth2 page lists the scopes an access token can request, but names only **api** and **api:v1**. OpsDuty issues a third scope, **mcp**, which grants access to the MCP API and is enforced the same way the other two are. A reader following this page to build an OAuth2 app would not know it exists or that they need to request it.

This adds the missing bullet, worded to match the scope description OpsDuty shows when a token is requested.

Verified against the platform's OAuth2 scope configuration. The neighbouring claims on the page still hold, so I left them alone: `scim:v2` is not currently issued and is correctly absent, and both access and refresh tokens do expire after 2 years as stated.

`make build` passes (mkdocs runs with `strict: true`) and prettier is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
