### PR TITLE
Document heartbeat check-in rate limit and POST support

### DIFF
--- a/docs/concepts/heartbeat-monitoring.md
+++ b/docs/concepts/heartbeat-monitoring.md
@@ -49,11 +49,14 @@ the option:
 ## Registering Check-Ins
 
 Periodic jobs must be configured to send a ping (check-in) to OpsDuty upon
-successful execution. This is done by sending an HTTP GET request to the
+successful execution. This is done by sending an HTTP GET or POST request to the
 environment-specific check-in URL, which can be copied from the environment menu
 under `Copy checkin URL...`.
 
 - **Authentication**: The check-in URL does not require authentication.
+- **Rate limit**: Check-ins are limited to 5 requests per minute per
+  environment. Requests above that limit are rejected with a HTTP 429 status
+  code and do not register a check-in.
 
 ## Programmatic Management of Heartbeats and Environments
 


### PR DESCRIPTION
The "Registering Check-Ins" section described the check-in URL as taking an HTTP GET request, and listed only one property of it (that it needs no authentication). Two user-facing behaviours were missing.

**The check-in endpoints accept POST as well as GET.** Jobs that ping with POST work today, but the page implies only GET does.

**Check-ins are rate limited to 5 requests per minute per heartbeat environment.** This was documented nowhere. Requests above the limit are rejected with HTTP 429 and do not register a check-in. That matters in practice: a job pinging more often than every 12 seconds silently loses check-ins, which is exactly the kind of thing you want to know before wiring up a frequent job.

Both behaviours were verified against the check-in endpoints and their error handling, including that the limit is keyed per heartbeat environment rather than per IP.

`make build` passes (mkdocs runs with `strict: true`) and prettier is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
