### PR TITLE
Describe the API reference correctly instead of Swagger

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -7,5 +7,5 @@ of the existing clients, but it is also possible to use tools like `curl` or
 
 ## Versions
 
-- [V1](https://opsduty.io/api/v1) - Current version [[Swagger](swagger.md)]
-  [[OpenAPI](openapi.md)]
+- [V1](https://opsduty.io/api/v1) - Current version
+  [[API reference](swagger.md)] [[OpenAPI](openapi.md)]

--- a/docs/api/swagger.md
+++ b/docs/api/swagger.md
@@ -1,7 +1,8 @@
-# Swagger documentation
+# API reference
 
-Swagger documentation is a tool for designing, visualizing, and interacting with
-RESTful APIs, based on the OpenAPI Specification.
+The API reference is an interactive view of the REST API, rendered with Scalar
+and generated from the [OpenAPI Specification](openapi.md). It lists the
+available endpoints together with their request and response schemas.
 
-OpsDuty exposes its Swagger documentation on
+OpsDuty exposes its API reference on
 [https://opsduty.io/api/v1/docs](https://opsduty.io/api/v1/docs).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,7 +112,7 @@ nav:
   - API:
       - Getting Started: api/index.md
       - OAuth2: api/oauth2.md
-      - Swagger: api/swagger.md
+      - API reference: api/swagger.md
       - OpenAPI: api/openapi.md
       - Clients:
           - Python:


### PR DESCRIPTION
The API section had a page titled "Swagger documentation" that described Swagger as the tool behind the interactive API docs. That is not what OpsDuty serves. The interactive reference at [https://opsduty.io/api/v1/docs](https://opsduty.io/api/v1/docs) is a Scalar API reference, not Swagger UI. Anyone opening that link lands on a Scalar page, down to the browser tab reading "Scalar", so the page named the wrong tool and then explained what that wrong tool does.

What changed:

- Retitled the page to "API reference" and rewrote its two sentences to describe what is actually served. The URL it points at was already correct and is unchanged.
- Updated the nav entry and the link on the API getting-started page to match.

I deliberately kept the file at `api/swagger.md` so the published URL <https://docs.opsduty.io/api/swagger/> keeps working. No redirect plugin is configured, so renaming the file would silently break any existing external link to it. Happy to rename the page properly if you would rather pull in a redirect plugin alongside it.

Verified against the v1 API's interactive documentation configuration and the path it is mounted at.

`make build` passes (mkdocs runs with `strict: true`) and prettier is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
