### PR TITLE
Document the webhook enqueue response

### DIFF
--- a/docs/concepts/integrations/webhooks.md
+++ b/docs/concepts/integrations/webhooks.md
@@ -39,3 +39,22 @@ The configured receiving channel processes the posted payload, generating an
 incident event. This event will either trigger a new incident (if no matching
 open incident with the same deduplication identifier exists) or be added to an
 existing open incident.
+
+### Response
+
+Incidents are created asynchronously, so a successful request returns HTTP 202
+Accepted with a reference instead of the incident itself:
+
+```json
+{ "incident_reference_id": "IRQ7M2XK9TBW4D" }
+```
+
+To find out what happened to the event, pass that value to the
+[REST API](../../api/index.md) endpoint
+`/api/v1/incidents/incident-reference/{incident_reference_id}/`. The reference
+reports a status of `pending`, `completed`, `failed` or `stopped`, along with a
+reason when the event did not complete.
+
+Requests to the webhook endpoint are limited to 10 per second for each
+combination of webhook and routing key. Requests above that limit are rejected
+with a HTTP 429 status code.


### PR DESCRIPTION
The webhooks page explains how to build the webhook URL and how the payload is parsed, then stops. It never says what a POST to that URL actually returns, which leaves out the part that surprises people: incidents are created asynchronously, so the response does not contain the incident.

Three user-facing behaviours were undocumented:

- A successful POST returns **202 Accepted** with an `incident_reference_id`, not the incident.
- That reference can be looked up through the REST API at `/api/v1/incidents/incident-reference/{incident_reference_id}/`, which reports a status of `pending`, `completed`, `failed` or `stopped`, plus a reason when the event did not complete. Without this, there is no documented way to tell whether an accepted event actually produced an incident.
- The endpoint is rate limited to 10 requests per second for each combination of webhook and routing key, and rejects requests over that limit with a 429.

I added a short "Response" section covering these and left the rest of the page alone. The existing webhook URL format on the page is correct, so it is unchanged.

Verified against the webhook enqueue endpoint and its rate limiting, the incident reference lookup endpoint in the v1 REST API, and the set of statuses a reference can report. The example reference id in the snippet matches the real identifier format.

`make build` passes (mkdocs runs with `strict: true`) and prettier is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
