### PR TITLE
Document indefinite incident silencing

### DIFF
--- a/docs/concepts/incidents.md
+++ b/docs/concepts/incidents.md
@@ -24,9 +24,14 @@ create a new incident or append the event to an existing one based on a
 
 ## Silence
 
-An incident can be silenced for a specific period. When silenced, OpsDuty pauses
-the escalation policy execution. If the incident is not acknowledged or resolved
-before the silence period ends, it will transition back to the triggered state.
+An incident can be silenced, which pauses the escalation policy execution. You
+can silence an incident for a specific period or leave it silenced indefinitely.
+
+When you set a period, the incident automatically returns to the triggered state
+once the period ends, unless it was acknowledged or resolved in the meantime.
+When you silence without a period, the incident stays silenced until you
+un-silence it. Un-silencing returns the incident to the triggered state and
+resumes the escalation policy.
 
 ## Reassign
 


### PR DESCRIPTION
The Silence section on the incidents concept page described only one way to silence an incident: "An incident can be silenced for a specific period... it will transition back to the triggered state" when the period ends. That reads as if a period is always required.

It is not. When you silence an incident you can either set a period or leave it silenced indefinitely:

- With a period, the incident automatically returns to the triggered state once the period ends, unless it was acknowledged or resolved in the meantime. This is what the page already described.
- Without a period, the incident stays silenced until someone un-silences it. The page did not mention this case at all.

I also made explicit what un-silencing does, since it applies to both cases: the incident returns to the triggered state and the escalation policy resumes.

I rewrote the three sentences in that section and left the rest of the page unchanged.

Verified against the incident silence and un-silence behaviour, including the optional silence duration and the automatic return to the triggered state when a duration is set.

`make build` passes (mkdocs runs with `strict: true`) and prettier is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
