### PR TITLE
Correct which integrations use the routing key

### DIFF
--- a/docs/concepts/escalations/services.md
+++ b/docs/concepts/escalations/services.md
@@ -23,9 +23,10 @@ concept. This allows you to select the destination service in OpsDuty using
 rules, rather than configuring the destination service at the source of the
 incident data.
 
-Currently, the routing key is only utilized by the webhook integration. To
-enable a service to process data, replace the `<routing-key>` portion of the URL
-with the specific routing key for that service.
+The routing key is used by the webhook and email integrations to select the
+destination service. For the webhook integration, replace the `<routing-key>`
+portion of the URL with the specific routing key for that service. For the email
+integration, you select the routing key when configuring the integration.
 
 Example Webhook URL:
 `https://opsduty.io/integrations/webhooks/enque/event/<webhook-integration-key>/<routing-key>`


### PR DESCRIPTION
The Services page said "Currently, the routing key is only utilized by the webhook integration." That is no longer true. The email integration also uses a routing key: when you configure an email integration you pick a routing key that sets the incident destination (a service or a routing rule), and it is a required field.

So a reader with an email integration would read this page and conclude routing keys do not apply to them, when they do.

I reworded that sentence to say the routing key is used by both the webhook and email integrations, and split the "how" into the two cases: for the webhook you put the routing key in the URL, for email you select it when configuring the integration. The webhook URL example below it is unchanged.

Verified against the webhook and email integrations and how each one resolves a routing key to a destination service, including that the email integration exposes routing key selection as a required setting.

`make build` passes (mkdocs runs with `strict: true`) and prettier is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
