### PR TITLE
Complete the Jinja truthy value list for routing rules

### DIFF
--- a/docs/concepts/event-processing/routing-rules.md
+++ b/docs/concepts/event-processing/routing-rules.md
@@ -82,8 +82,8 @@ selected field. The available operations are:
   selected field.
 - **Exists**: Matches if the selected field exists.
 - **Jinja Expression**: Matches if the Jinja template returns a truthy value
-  (e.g., `y`, `yes`, `true`, `on`, `1`, `ok`). The selected field is available
-  as the `field` variable.
+  (`y`, `yes`, `t`, `true`, `on`, `1` or `ok`, case-insensitive). The selected
+  field is available as the `field` variable.
 - **Matches**: Matches if the selected field is equal to the specified value.
 - **Matches part**: Matches if the selected field contains the specified value.
 - **Matches regex**: Matches if the specified regex matches the selected field.


### PR DESCRIPTION
On the Routing Rules page, the Jinja Expression filter operation lists the values that count as truthy as "e.g., `y`, `yes`, `true`, `on`, `1`, `ok`". The actual set a Jinja expression is checked against also includes `t`, and the comparison is case-insensitive. So the list was one value short and presented as a vague example rather than the real set.

I replaced it with the complete list (`y`, `yes`, `t`, `true`, `on`, `1` or `ok`) and noted that the match is case-insensitive. A reader writing a Jinja condition can now rely on the list instead of guessing.

Verified against the truthy-value check used to evaluate Jinja filter conditions.

`make build` passes (mkdocs runs with `strict: true`) and prettier is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
