### PR TITLE
Fix garbled event orchestration scoping sentence

### DIFF
--- a/docs/concepts/event-processing/event-orchestrations.md
+++ b/docs/concepts/event-processing/event-orchestrations.md
@@ -5,10 +5,10 @@ is utilized when the service receives new events.
 Event orchestrations allow for the configuration of transformations, which
 dictate how OpsDuty processes incoming events.
 
-A routing rule generally applies to a service but can be limited to a specific
-routing rule. Event orchestration will only be used if the routing rule directs
-the event to the associated event orchestration service. This provides a way to
-restrict the use of event orchestrations.
+An event orchestration generally applies to a service but can be limited to a
+specific routing rule. When limited, the event orchestration is only used if the
+event was routed to its service through that routing rule. This provides a way
+to restrict the use of event orchestrations.
 
 ## Conditions
 


### PR DESCRIPTION
The Event Orchestrations page had a garbled sentence describing how an orchestration is scoped:

"A routing rule generally applies to a service but can be limited to a specific routing rule."

That is self-contradictory (a routing rule limited to a routing rule) and names the wrong subject. The sentence is about the event orchestration, not the routing rule. An event orchestration always applies to a service, and can optionally be limited to a single routing rule, in which case it only runs when the event reached that service through that routing rule. The surrounding sentences already talk about restricting event orchestrations, so the subject of this one was simply wrong.

I rewrote the sentence so the subject is the event orchestration and the scoping condition reads correctly. No other content on the page changed.

Verified against how an event orchestration binds to a service and to an optional routing rule that gates when it runs.

`make build` passes (mkdocs runs with `strict: true`) and prettier is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
