### PR TITLE
Fix the Slack on-call and trigger commands

### DIFF
--- a/docs/concepts/integrations/slack.md
+++ b/docs/concepts/integrations/slack.md
@@ -47,10 +47,9 @@ incident in OpsDuty directly from a message in a Slack channel.
 
 #### Who is On-Call?
 
-Type `/who` in Slack to access the "Who is on-call?" shortcut. This allows you
-to quickly find the responsible responder for a specific service.
+Type `/opsduty oncall` in Slack to quickly find the responder currently on call
+for a specific service.
 
 #### Trigger Incident
 
-Type `/trigger` in Slack to access the "Trigger New Incident" shortcut. This
-feature enables you to initiate a new incident directly from Slack.
+Type `/opsduty trigger` in Slack to start a new incident directly from Slack.


### PR DESCRIPTION
The Slack integration page told users to type `/who` to see who is on call and `/trigger` to start an incident. Neither is a real command. The integration registers a single slash command, `/opsduty`, and everything runs as a subcommand of it. Typing `/who` or `/trigger` in Slack does nothing.

The correct commands are `/opsduty oncall` and `/opsduty trigger`. Both appear in the output of `/opsduty help`, so a user who ran the documented help command would already see that the page was wrong.

I replaced the two invented commands with the real ones and dropped the surrounding claim that they open a named shortcut, since they are slash commands. The rest of the page, including the account linking and help commands that were already correct, is unchanged.

Verified against the registered Slack slash command and the built-in command list shown by the help command.

`make build` passes (mkdocs runs with `strict: true`) and prettier is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
