### PR TITLE
Match test notification button labels to the UI

### DIFF
--- a/docs/apps/notifications.md
+++ b/docs/apps/notifications.md
@@ -38,9 +38,8 @@ Your device is listed below the `Push devices` section on the
 [Notifications](https://opsduty.io/app/user/notifications) page in OpsDuty after
 you have downloaded the App and logged in.
 
-You can send a test push message to the devices by pressing "Send test
-notification with high urgency" or "Send test notification with low urgency" in
-the device menu.
+You can send a test push message to the devices by pressing "Send test (high
+urgency)" or "Send test (low urgency)" in the device menu.
 
 ## Limitations
 


### PR DESCRIPTION
The Notifications page tells you to press "Send test notification with high urgency" or "Send test notification with low urgency" in the device menu. Those are not the labels on the buttons. The device menu actions are labelled "Send test (high urgency)" and "Send test (low urgency)".

A reader scanning the menu for the quoted text would not find it. I updated the two quoted labels to match what the menu actually shows. No other change.

Verified against the push-device menu actions on the notifications page.

`make build` passes (mkdocs runs with `strict: true`) and prettier is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
