### PR TITLE
Match incoming-call purchase button labels to the UI

### DIFF
--- a/docs/concepts/integrations/incoming-calls.md
+++ b/docs/concepts/integrations/incoming-calls.md
@@ -42,10 +42,11 @@ need voice and SMS notifications when new incidents are triggered.
 
 #### Purchase a New Number
 
-1. Click "Purchase Number".
+1. Click "Purchase number".
 2. Select a country and number type, scroll down, and click "Search".
 3. You will see a list of available numbers along with their monthly prices.
-4. Click "Purchase Number". This step will affect your Twilio account balance.
+4. Click "Purchase" next to the number you want. This step will affect your
+   Twilio account balance.
 5. The new number will now appear in your list of numbers.
 
 #### Configure a Phone Number


### PR DESCRIPTION
The steps for buying an incoming-call number quoted two buttons that do not match what the interface shows.

- Step 1 said click "Purchase Number". The button is labelled "Purchase number".
- Step 4 said click "Purchase Number" again. In the list of available numbers, the button on each row is just "Purchase". I updated the step to "Click 'Purchase' next to the number you want" so it matches and makes clear the action is per row.

Only the two button labels in that numbered procedure changed. The billing note about the purchase affecting the Twilio balance is unchanged.

Verified against the incoming-call number purchase screens and the labels on their buttons.

`make build` passes (mkdocs runs with `strict: true`) and prettier is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
