### PR TITLE
Document the incoming-call greeting settings

### DIFF
--- a/docs/concepts/integrations/incoming-calls.md
+++ b/docs/concepts/integrations/incoming-calls.md
@@ -65,3 +65,10 @@ need voice and SMS notifications when new incidents are triggered.
     them to the responsible person for the selected destination service. If only
     one destination is configured, the caller will not be presented with
     alternative options.
+
+    !!! note "Caller greeting"
+
+        Set a "Greeting message" to have OpsDuty read a short message to the
+        caller before the destination options. Enable "Skip service name read
+        out" if you do not want OpsDuty to read the selected service name to the
+        caller.


### PR DESCRIPTION
The "Configure a Phone Number" steps cover the destination menu but skip the settings that control what the caller actually hears. Two of those are undocumented:

- "Greeting message" - a message OpsDuty reads to the caller before presenting the destination options.
- "Skip service name read out" - stops OpsDuty from reading the selected service name to the caller.

Both are on the same number configuration page as the destinations, so a reader setting up a number has no pointer to them today. I added a short note under the destinations step describing both, using the labels as they appear on the page.

Verified against the phone number configuration options and the order in which the greeting and destination menu are presented to a caller.

`make build` passes (mkdocs runs with `strict: true`) and prettier is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
